### PR TITLE
Do not render table when dataset schema is empty

### DIFF
--- a/src/components/dataset-dictionary/dataset-dictionary.js
+++ b/src/components/dataset-dictionary/dataset-dictionary.js
@@ -57,6 +57,8 @@ const columns = [
   }
 ]
 
+const isEmpty = schema => !schema || schema.length < 1
+
 const SchemaTable = ({ schema, parentFieldName = '', style }) => {
   return (
     <div className={`dataset-schema-table ${parentFieldName}`}>
@@ -78,12 +80,12 @@ const SchemaTable = ({ schema, parentFieldName = '', style }) => {
 
 export default ({ schema, expanded = false }) => {
   var title = 'Data Dictionary'
-  if (!schema) { title = title + ' Unavailable' }
+  if (isEmpty(schema)) { title = title + ' Unavailable' }
 
   return (
     <dataset-dictionary>
       <CollapsableBox title={title} expanded={expanded}>
-        <SchemaTable schema={schema} />
+        {!isEmpty(schema) && <SchemaTable schema={schema} />}
       </CollapsableBox>
     </dataset-dictionary>
   )

--- a/src/components/dataset-dictionary/dataset-dictionary.test.js
+++ b/src/components/dataset-dictionary/dataset-dictionary.test.js
@@ -181,12 +181,34 @@ describe('dataset dictionary', () => {
   })
 
   describe('without a schema', () => {
-    it('renders the collapsable box with an informative message', () => {
-      subject = shallow(<DatasetDictionary />)
+    beforeEach(() => {
+      subject = shallow(<DatasetDictionary expanded />)
+    })
 
+    it('renders the collapsable box with an informative message', () => {
       const collapsableBox = subject.find(CollapsableBox)
       expect(collapsableBox.length).toBe(1)
       expect(collapsableBox.props().title).toBe("Data Dictionary Unavailable")
+    })
+
+    it('does not render the table', () => {
+      expect(subject.find('.dataset-schema-table').length).toBe(0)
+    })
+  })
+
+  describe('with an empty schema', () => {
+    beforeEach(() => {
+      subject = mount(<DatasetDictionary schema={[]} expanded />)
+    })
+
+    it('renders the collapsable box with an informative message', () => {
+      const collapsableBox = subject.find(CollapsableBox)
+      expect(collapsableBox.length).toBe(1)
+      expect(collapsableBox.props().title).toBe("Data Dictionary Unavailable")
+    })
+
+    it('does not render the table', () => {
+      expect(subject.find('.dataset-schema-table').length).toBe(0)
     })
   })
 


### PR DESCRIPTION
smartcitiesdata/discovery-ui#133

co-authored-by: Tony Brock <anthony.brock@accenture.com>