### PR TITLE
Data dictionary list types not displaying properly

### DIFF
--- a/src/components/dataset-dictionary/dataset-dictionary.js
+++ b/src/components/dataset-dictionary/dataset-dictionary.js
@@ -16,13 +16,13 @@ const renderFieldNameCell = schemaElement => (
 const renderTypeCell = schemaElement => (
   <div>
     {schemaElement.value === 'list'
-      ? `list of ${schemaElement.original.listType}`
+      ? `list of ${schemaElement.original.itemType}`
       : schemaElement.value}
   </div>
 )
 
 const isMap = schemaElement => {
-  return schemaElement.type === 'map' || schemaElement.listType === 'map'
+  return schemaElement.type === 'map' || schemaElement.itemType === 'map'
 }
 
 const renderExpander = ({ isExpanded, original: schemaElement }) => {

--- a/src/components/dataset-dictionary/dataset-dictionary.test.js
+++ b/src/components/dataset-dictionary/dataset-dictionary.test.js
@@ -65,7 +65,7 @@ describe('dataset dictionary', () => {
   describe('with a schema containing a list type', () => {
     it('displays the list type appropriately', () => {
       const schemaWithList = [
-        { name: 'names', type: 'list', description: 'all the names', listType: 'string' }
+        { name: 'names', type: 'list', description: 'all the names', itemType: 'string' }
       ]
 
       subject = mount(<DatasetDictionary schema={schemaWithList} expanded />)
@@ -74,7 +74,7 @@ describe('dataset dictionary', () => {
       const cells = table.find('.rt-td')
 
       const typeIndex = 2;
-      expect(cells.at(typeIndex).text()).toBe(`list of ${schemaWithList[0].listType}`)
+      expect(cells.at(typeIndex).text()).toBe(`list of ${schemaWithList[0].itemType}`)
     })
   })
 
@@ -85,7 +85,7 @@ describe('dataset dictionary', () => {
         name: 'mother', type: 'map', description: 'the mother', subSchema: [
           { name: 'name', type: 'string', description: 'mother\'s name' },
           {
-            name: 'children', type: 'list', description: 'the chillins', listType: 'map', subSchema: [
+            name: 'children', type: 'list', description: 'the chillins', itemType: 'map', subSchema: [
               { name: 'age', type: 'integer', description: 'the child\'s age' }
             ]
           }


### PR DESCRIPTION
fixed bug where we were referring to the wrong property on the schema to determine a list's item type